### PR TITLE
Fix array out-of-bounds when choosing an image

### DIFF
--- a/shitposter.py
+++ b/shitposter.py
@@ -35,7 +35,7 @@ def thread_prop( images, board, thread_id ):
     except ( urllib.error.HTTPError ):
         return retval
     
-    data = json.loads( response.readall().decode('utf-8') )
+    data = json.loads( response.read().decode('utf-8') )
 
     for post in data['posts']:
         if 'com' in post:
@@ -54,7 +54,7 @@ def analyze_board( mc, board ):
     print( 'Training... (may take a while)' )
     
     response = urllib.request.urlopen( 'http://a.4cdn.org/' + board + '/threads.json' )
-    data = json.loads( response.readall().decode('utf-8') )
+    data = json.loads( response.read().decode('utf-8') )
 
     for page in data:
         for thread in page['threads']:

--- a/shitposter.py
+++ b/shitposter.py
@@ -9,7 +9,7 @@ import urllib.error
 import urllib.request
 
 from pymarkovchain import MarkovChain
-from random import randint
+from random import choice
 
 html_rep = {
     '&amp;' : '&',
@@ -86,7 +86,7 @@ def load_or_train_board( board ):
 
 def shitpost_loop( mc, images, board ):
     read = ''
-    image_grab = lambda : 'http://i.4cdn.org/' + board + '/' + images[randint( 0, len( images ) )]
+    image_grab = lambda : 'http://i.4cdn.org/' + board + '/' + choice(images)
     
     print( 'Hit enter to generate a shitpost, or enter ? for a list of valid commands.' )
 


### PR DESCRIPTION
`random.randint(a, b)` includes both endpoints `a` and `b` within its
possibilities, so sometimes the random number returned is out of the
bounds of the array.

Instead of it use `random.choice`, that has no such problem.

Also replace `readall()` with `read()`, this helps with Windows compatibility according to >>>/g/52248094